### PR TITLE
feat: add Mixpanel integration and move Sentry DSN to env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Mixpanel
+NEXT_PUBLIC_MIXPANEL_TOKEN=your_mixpanel_token_here

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
+# Sentry
+NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn_here
+
 # Mixpanel
 NEXT_PUBLIC_MIXPANEL_TOKEN=your_mixpanel_token_here

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tailwindcss/postcss": "^4.2.4",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
+        "mixpanel-browser": "^2.78.0",
         "motion": "^12.38.0",
         "next": "16.2.4",
         "next-intl": "^4.11.0",
@@ -2285,6 +2286,62 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mixpanel/rrdom": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrdom/-/rrdom-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-58sWLQDPRU0VQn8VzB1tx4ujih9X327Vr6xAzbJ4zge9GENm2L696T4TbWvrRGWPW6w99tHIHbv6SvcLhjjmcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18"
+      }
+    },
+    "node_modules/@mixpanel/rrweb": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb/-/rrweb-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-ICpEYDFEEiCoUuQg+de3VvQCsolF4lNHfEM9DBp5Pwuc7EgXqwWV4wUpiRF/NbhoKk+82X1Qe+oqqlKJb/CGFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixpanel/rrdom": "^2.0.0-alpha.18",
+        "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18",
+        "@mixpanel/rrweb-types": "^2.0.0-alpha.18",
+        "@mixpanel/rrweb-utils": "^2.0.0-alpha.18",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0"
+      }
+    },
+    "node_modules/@mixpanel/rrweb-plugin-console-record": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-plugin-console-record/-/rrweb-plugin-console-record-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-gGxEnNpfWurQht+fpSJbwPV60ug0LAENlk4Ux3XRmYooNJGPBO1TiQHcM7g0yhrKf4tfbTiKKZ4EXzFlOZs/pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@mixpanel/rrweb": "^2.0.0-alpha.18",
+        "@mixpanel/rrweb-utils": "^2.0.0-alpha.18"
+      }
+    },
+    "node_modules/@mixpanel/rrweb-snapshot": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-ubLGwgPiMMi0rl7zJRh1uMScQ480lT95tkHkIAHkiZOemMY4JSkYZh2v9fpMNwJhaGwB5n/76KI7Cwy8F5qixQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/@mixpanel/rrweb-types": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-types/-/rrweb-types-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-7kRuk7pK6Firrb26Mm235Po7s/z+9k0gUKZU/DZkzg5U1yQRcsu4byIrnWTiTQr+LFLUrIiyRKnpGK/QneAhTw==",
+      "license": "MIT"
+    },
+    "node_modules/@mixpanel/rrweb-utils": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-utils/-/rrweb-utils-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-c3nUbQl19kxHjf8nowFMeXlJw0ZqLesIVBb9t4g1nC4WtaNEPkFotWRdGt5V2cJNQ+aY38/v2uYb8Ren4IcdSQ==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -5477,6 +5534,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -5543,6 +5606,12 @@
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
+    },
+    "node_modules/@types/json-logic-js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-logic-js/-/json-logic-js-2.0.5.tgz",
+      "integrity": "sha512-hu/FTi0zwCjQEFfbPur275cNoZj6NsuOBhhYNzqoSdfmMhuxFr58OZ957lyIOWc9+kO+2tFlBthRjcxuytD4HA==",
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -6491,6 +6560,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -7017,6 +7092,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.23",
@@ -11152,6 +11236,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-logic-js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.5.tgz",
+      "integrity": "sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==",
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -11760,6 +11850,28 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/mixpanel-browser": {
+      "version": "2.78.0",
+      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.78.0.tgz",
+      "integrity": "sha512-K2nsMLnTK0PXcQxhj1aJyGpKyEfo2u7wgZhVm532DTjkoCbJJkuSjDBWJFCH5agEM5oE0aVoCYKd0hZ+i8LsYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mixpanel/rrweb": "2.0.0-alpha.18.4",
+        "@mixpanel/rrweb-plugin-console-record": "2.0.0-alpha.18.4",
+        "@mixpanel/rrweb-utils": "2.0.0-alpha.18.4",
+        "@types/json-logic-js": "2.0.5",
+        "json-logic-js": "2.0.5"
+      },
+      "engines": {
+        "node": ">=20 <26"
       }
     },
     "node_modules/module-details-from-path": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/postcss": "^4.2.4",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
+    "mixpanel-browser": "^2.78.0",
     "motion": "^12.38.0",
     "next": "16.2.4",
     "next-intl": "^4.11.0",

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,7 +6,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://72a10c22d8b66638f1beb39b8deee486@o4506790144245760.ingest.us.sentry.io/4506791074922496",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://72a10c22d8b66638f1beb39b8deee486@o4506790144245760.ingest.us.sentry.io/4506791074922496",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -6,7 +6,7 @@ import { replayIntegration } from "@sentry/browser";
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://72a10c22d8b66638f1beb39b8deee486@o4506790144245760.ingest.us.sentry.io/4506791074922496",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Add optional integrations for additional features
   integrations: [replayIntegration()],

--- a/src/provider/AppProvider.tsx
+++ b/src/provider/AppProvider.tsx
@@ -3,11 +3,14 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import { type PropsWithChildren } from "react";
 
 import { LanguageProvider } from "./src/LanguageProvider";
+import { MixpanelProvider } from "./src/MixpanelProvider";
 
 export const AppProvider = ({ children }: PropsWithChildren) => (
   <LanguageProvider>
-    {children}
-    <Analytics />
-    <SpeedInsights />
+    <MixpanelProvider>
+      {children}
+      <Analytics />
+      <SpeedInsights />
+    </MixpanelProvider>
   </LanguageProvider>
 );

--- a/src/provider/src/MixpanelProvider.tsx
+++ b/src/provider/src/MixpanelProvider.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import mixpanel from "mixpanel-browser";
+import { useEffect, type PropsWithChildren } from "react";
+
+const token = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
+
+export const MixpanelProvider = ({ children }: PropsWithChildren) => {
+  useEffect(() => {
+    if (!token) return;
+    mixpanel.init(token, {
+      autocapture: true,
+      record_sessions_percent: 100,
+      track_pageview: true,
+      persistence: "localStorage",
+    });
+  }, []);
+
+  return <>{children}</>;
+};


### PR DESCRIPTION
## Summary

- Adds `MixpanelProvider` with autocapture, session recording (100%), and pageview tracking
- Wraps `AppProvider` with `MixpanelProvider` (skips init if token is missing)
- Moves hardcoded Sentry DSN to `NEXT_PUBLIC_SENTRY_DSN` env variable across all three Sentry config files
- Creates `.env.example` documenting both `NEXT_PUBLIC_SENTRY_DSN` and `NEXT_PUBLIC_MIXPANEL_TOKEN`

## Test plan

- [ ] Add `NEXT_PUBLIC_MIXPANEL_TOKEN` and `NEXT_PUBLIC_SENTRY_DSN` to `.env.local` and Vercel environment variables
- [ ] Verify Mixpanel events appear in the Mixpanel dashboard on page load
- [ ] Verify Sentry errors are still reported correctly in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)